### PR TITLE
Adding support to Java8 equip

### DIFF
--- a/equip_java8.sh
+++ b/equip_java8.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+#
+# Ubuntu Equip 
+#  Java 8 Equip
+# Licence: MIT
+
+sudo echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
+wget --no-check-certificate https://github.com/aglover/ubuntu-equip/raw/master/equip_base.sh && bash equip_base.sh
+
+sudo add-apt-repository ppa:webupd8team/java
+sudo apt-get update -y
+sudo apt-get install oracle-java8-installer -y
+sudo apt-get install ant -y


### PR DESCRIPTION
This commit adds the support to Java8. The automation is based on the original Java
support, plus some insights about how to accept the terms and conditions automatically
as described by http://www.webupd8.org/2012/09/install-oracle-java-8-in-ubuntu-via-ppa.html

The step is also included in the shell.

"vagrant up" installed Java8 properly:

mdesales@Marcello-Work ~/dev/workboxes/main2014 (mac) $ vagrant ssh
Welcome to Ubuntu Trusty Tahr (development branch) (GNU/Linux 3.13.0-11-generic x86_64)
- Documentation:  https://help.ubuntu.com/
  
  System information as of Thu Mar 20 00:02:25 UTC 2014
  
  System load:  0.53              Processes:           88
  Usage of /:   3.0% of 39.34GB   Users logged in:     0
  Memory usage: 28%               IP address for eth0: 10.0.2.15
  Swap usage:   0%
  
  Graph this data and manage this system at:
    https://landscape.canonical.com/
  
  Get cloud support with Ubuntu Advantage Cloud Guest:
    http://www.ubuntu.com/business/services/cloud

0 packages can be updated.
0 updates are security updates.

vagrant@vagrant-ubuntu-trusty-64:~$ java -version
java version "1.8.0"
Java(TM) SE Runtime Environment (build 1.8.0-b132)
Java HotSpot(TM) 64-Bit Server VM (build 25.0-b70, mixed mode)
vagrant@vagrant-ubuntu-trusty-64:~$
