### PR TITLE
Updated JDK7 Installation with 1.7.0_55

### DIFF
--- a/equip_java7_64.sh
+++ b/equip_java7_64.sh
@@ -10,7 +10,7 @@ wget --no-check-certificate https://github.com/aglover/ubuntu-equip/raw/master/e
 
 sudo apt-get install curl -y 
 
-curl -L --cookie "oraclelicensejdk-7u25-b15-oth-JPR=accept-securebackup-cookie;gpw_e24=http://edelivery.oracle.com" http://download.oracle.com/otn-pub/java/jdk/7u55-b13/jdk-7u55-linux-x64.tar.gz -o jdk-7-linux-x64.tar.gz
+curl -L --cookie "oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/7u55-b13/jdk-7u55-linux-x64.tar.gz -o jdk-7-linux-x64.tar.gz
 tar -xvf jdk-7-linux-x64.tar.gz
 
 sudo mkdir -p /usr/lib/jvm


### PR DESCRIPTION
I updated the equip_java7_64.sh script to point at the most recent JDK7 version and updated the cookie reference so curl wouldn't fail. I tested using my fork and it deploys and installs correctly using Vagrant. I hope this resolves #6.
