### PR TITLE
New script to install JBoss AS 7.1.1

### DIFF
--- a/equip_jboss.sh
+++ b/equip_jboss.sh
@@ -4,7 +4,7 @@
 # Ubuntu Equip 
 #  Apache Ant Equip
 # Licence: MIT
-# thanks to http://raycoding.net/2013/02/15/installing-ant-on-ubuntu-or-linux-box/
+# based on equipe_ant.sh
 
 wget --no-check-certificate https://github.com/aglover/ubuntu-equip/raw/master/equip_base.sh && bash equip_base.sh
 


### PR DESCRIPTION
This new script will download and install JBoss AS 7.1.1. 

Based on equip_ant.sh.

Download the jboss-as-7.1.1.Final.tar.gz from JBoss.org site and install on /opt/jboss
