### PR TITLE
Update Ant download link

### DIFF
--- a/equip_ant.sh
+++ b/equip_ant.sh
@@ -8,14 +8,14 @@
 
 wget --no-check-certificate https://github.com/aglover/ubuntu-equip/raw/master/equip_base.sh && bash equip_base.sh
 
-wget http://apache.mirrors.pair.com/ant/binaries/apache-ant-1.9.2-bin.tar.gz
+wget http://apache.mirrors.pair.com/ant/binaries/apache-ant-1.9.4-bin.tar.gz
 
-tar -zxf apache-ant-1.9.2-bin.tar.gz
-sudo mv apache-ant-1.9.2 /usr/local
+tar -zxf apache-ant-1.9.4-bin.tar.gz
+sudo mv apache-ant-1.9.4 /usr/local
 
-sudo ln -s /usr/local/apache-ant-1.9.2/bin/ant /usr/bin/ant
+sudo ln -s /usr/local/apache-ant-1.9.4/bin/ant /usr/bin/ant
 
-rm apache-ant-1.9.2-bin.tar.gz
+rm apache-ant-1.9.4-bin.tar.gz
 
 
 # Open up ~/.bashrc and add the below lines


### PR DESCRIPTION
Ant 1.9.2 is not available anymore from the download page, so updated to stable release 1.9.4