### PR TITLE
Aligning with MongoDB official documentation:

### DIFF
--- a/equip_mongodb.sh
+++ b/equip_mongodb.sh
@@ -10,9 +10,8 @@ sudo apt-get install tcsh git-core scons g++ -y
 sudo apt-get install libpcre++-dev libboost-dev libreadline-dev xulrunner-1.9.1-dev -y
 sudo apt-get install libboost-program-options-dev libboost-thread-dev libboost-filesystem-dev libboost-date-time-dev -y
 
-
-sudo sh -c 'echo "deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen" > /etc/apt/sources.list.d/mongo-stable.list'
+sudo sh -c 'echo "deb http://repo.mongodb.org/apt/ubuntu "$(lsb_release -sc)"/mongodb-org/3.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.0.list'
 
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv 7F0CEB10
 sudo apt-get update -y
-sudo apt-get install mongodb-10gen -y
+sudo apt-get install -y mongodb-org


### PR DESCRIPTION
The current `equip_mongodb.sh` script is using a deprecate naming convention and repo url.
I've just added a change to reflect the change and to be aligned with the official MongoDB documentation - http://docs.mongodb.org/manual/tutorial/install-mongodb-on-ubuntu/
